### PR TITLE
ci: use workflow_run to allow secrets on dependabot and fork PRs

### DIFF
--- a/.github/workflows/CI-init.yml
+++ b/.github/workflows/CI-init.yml
@@ -1,0 +1,22 @@
+---
+# this workflow initializes a secondary workflow that will have access to secrets
+name: CI-init
+
+on:
+  pull_request:
+    branches: [master]
+    types: [opened, synchronize, reopened]
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  initialize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: pass
+        run: exit 0

--- a/.github/workflows/CI-run.yml
+++ b/.github/workflows/CI-run.yml
@@ -1,13 +1,12 @@
 ---
-name: CI
+name: CI-run
 
 on:
-  pull_request:
-    branches: [master]
-    types: [opened, synchronize, reopened]
-  push:
-    branches: [master]
-  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - CI-init
+    types:
+      - completed
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -17,8 +16,27 @@ jobs:
   action:
     runs-on: ubuntu-latest
     steps:
+      # tell the PR that the action is running
+#      - name: Set status to running
+#        if: ${{ github.event.workflow_run.conclusion == 'success' }}
+#        uses: actions/github-script@v6
+#        with:
+#          script: |
+#            github.repos.createCommitStatus({
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              sha: context.sha,
+#              state: 'pending',
+#              context: 'CI-run',
+#              description: 'Running CI-run',
+#              target_url: '${{ github.event.workflow_run.event.html_url }}',
+#            })
+
+      # checkout the PR merge commit
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_commit.id || github.sha }}
 
       - name: Setup Release
         id: setup-release
@@ -31,10 +49,12 @@ jobs:
       - name: Set action variables
         id: vars
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ]; then
+          # check if original workflow was a "pull_request"
+          
+          if [ "${{ github.event.workflow_run.event_name }}" == "pull_request" ]; then
             discussion_category=tests
             publish_pre_release=true
-            release_tag=pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
+            release_tag=pr-${{ github.event.workflow_run.event.number }}-${{ github.run_number }}
             token=${{ secrets.GITHUB_TOKEN }}
           else
             discussion_category=announcements
@@ -64,13 +84,29 @@ jobs:
           token: ${{ steps.vars.outputs.token }}
 
       - name: Sleep
-        if: ${{ always() && github.event_name == 'pull_request' }}
-        run: sleep 30
+        if: ${{ always() && github.event.workflow_run.event_name == 'pull_request' }}
+        run: sleep 120
 
       - name: Delete Release
         env:
           GITHUB_TOKEN: ${{ steps.vars.outputs.token }}
-        if: ${{ always() && github.event_name == 'pull_request' }}
+        if: ${{ always() && github.event.workflow_run.event_name == 'pull_request' }}
         uses: dev-drprasad/delete-tag-and-release@v0.2.1
         with:
           tag_name: ${{ steps.vars.outputs.release_tag }}
+
+      # tell the PR that the action is complete
+#      - name: Update status
+#        if: always()
+#        uses: actions/github-script@v6
+#        with:
+#          script: |
+#            github.repos.createCommitStatus({
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              sha: context.sha,
+#              state: '${{ job.status }}',
+#              context: 'CI-run',
+#              description: 'CI-run ${{ job.status }}',
+#              target_url: '${{ github.event.workflow_run.event.html_url }}',
+#            })


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
This PR should fix the ability of dependabot and PRs from forks to properly run the CI in this repo.

Todo:
- [ ] Determine if this will automatically add statuses for the sha, so they will be visible as status checks in PRs.
  - [ ] If yes, remove commented out blocks
  - [ ] If no, enable commented out blocks


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->
- Fixes #17 


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
