### PR TITLE
fix!: change default behavior of artifactErrorsFailBuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,20 +24,21 @@ steps:
 
 ## Inputs
 
-| Name                   | Description                                                                                       | Default         | Required |
-|------------------------|---------------------------------------------------------------------------------------------------|-----------------|----------|
-| allowUpdates           | An optional flag which indicates if we should update a release if it already exists.              | `true`          | `false`  |
-| artifacts              | The artifacts to upload.                                                                          | `*artifacts/*`  | `false`  |
-| body                   | The body of the release.                                                                          |                 | `false`  |
-| deleteOtherPreReleases | Whether to delete other pre-releases.                                                             | `true`          | `false`  |
-| deletePreReleaseTags   | Whether to delete other pre-release tags.                                                         | `true`          | `false`  |
-| discussionCategory     | The category for the discussion.                                                                  | `announcements` | `false`  |
-| generateReleaseNotes   | Indicates if release notes should be automatically generated.                                     | `true`          | `false`  |
-| keepPreReleaseCount    | The number of pre-releases to keep.                                                               | `2`             | `false`  |
-| name                   | The version to create.                                                                            |                 | `true`   |
-| prerelease             | Whether the release is a prerelease.                                                              | `true`          | `false`  |
-| tag                    | The tag to create.                                                                                |                 | `true`   |
-| token                  | GitHub Token.                                                                                     |                 | `true`   |
+| Name                    | Description                                                                                          | Default         | Required |
+|-------------------------|------------------------------------------------------------------------------------------------------|-----------------|----------|
+| allowUpdates            | An optional flag which indicates if we should update a release if it already exists.                 | `true`          | `false`  |
+| artifactErrorsFailBuild | An optional flag which indicates if we should fail the build if there are errors with the artifacts. | `false`         | `false`  |
+| artifacts               | The artifacts to upload.                                                                             | `*artifacts/*`  | `false`  |
+| body                    | The body of the release.                                                                             |                 | `false`  |
+| deleteOtherPreReleases  | Whether to delete other pre-releases.                                                                | `true`          | `false`  |
+| deletePreReleaseTags    | Whether to delete other pre-release tags.                                                            | `true`          | `false`  |
+| discussionCategory      | The category for the discussion.                                                                     | `announcements` | `false`  |
+| generateReleaseNotes    | Indicates if release notes should be automatically generated.                                        | `true`          | `false`  |
+| keepPreReleaseCount     | The number of pre-releases to keep.                                                                  | `2`             | `false`  |
+| name                    | The version to create.                                                                               |                 | `true`   |
+| prerelease              | Whether the release is a prerelease.                                                                 | `true`          | `false`  |
+| tag                     | The tag to create.                                                                                   |                 | `true`   |
+| token                   | GitHub Token.                                                                                        |                 | `true`   |
 
 ## See Also
 

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,10 @@ inputs:
     description: 'An optional flag which indicates if we should update a release if it already exists.'
     required: false
     default: 'true'
+  artifactErrorsFailBuild:
+    description: 'An optional flag which indicates if we should fail the build if there are errors with the artifacts.'
+    required: false
+    default: 'false'
   artifacts:
     description: 'The artifacts to upload.'
     required: false
@@ -59,7 +63,7 @@ runs:
       uses: ncipollo/release-action@v1.14.0
       with:
         allowUpdates: ${{ inputs.allowUpdates }}
-        artifactErrorsFailBuild: true
+        artifactErrorsFailBuild: ${{ inputs.artifactErrorsFailBuild }}
         artifacts: ${{ inputs.artifacts }}
         body: ${{ inputs.body }}
         commit: ${{ github.sha }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Change default behavior of `artifactErrorsFailBuild` and make it an optional input.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
