### PR TITLE
fix(action): add delay when deleting tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ steps:
 | keepPreReleaseCount     | The number of pre-releases to keep.                                                                  | `2`             | `false`  |
 | name                    | The version to create.                                                                               |                 | `true`   |
 | prerelease              | Whether the release is a prerelease.                                                                 | `true`          | `false`  |
+| sleepDuration           | The duration to sleep in seconds before deleting tags.                                               | `15`            | `false`  |
 | tag                     | The tag to create.                                                                                   |                 | `true`   |
 | token                   | GitHub Token.                                                                                        |                 | `true`   |
 

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,10 @@ inputs:
     description: 'Whether the release is a prerelease.'
     required: false
     default: 'true'
+  sleepDuration:
+    description: 'The duration to sleep in seconds before deleting tags.'
+    required: false
+    default: '15'
   tag:
     description: 'The tag to create.'
     required: true
@@ -90,12 +94,14 @@ runs:
       env:
         DELETE_TAGS: ${{ inputs.deletePreReleaseTags }}
         KEEP_LATEST: ${{ inputs.keepPreReleaseCount }}
+        SLEEP_DURATION: ${{ inputs.sleepDuration }}
       with:
         github-token: ${{ inputs.token }}
         script: |
           // process input
           const DELETE_TAGS = process.env.DELETE_TAGS.toLowerCase() === 'true';
           const KEEP_LATEST = parseInt(process.env.KEEP_LATEST, 10);
+          const SLEEP_DURATION = parseInt(process.env.SLEEP_DURATION, 10);
 
           console.log(`DELETE_TAGS: ${DELETE_TAGS}`);
           console.log(`KEEP_LATEST: ${KEEP_LATEST}`);
@@ -145,8 +151,14 @@ runs:
               console.error(`Failed to delete release: ${release.tag_name}`);
               console.error(error);
             }
+          }
 
-            if (DELETE_TAGS) {
+          // sleep to allow any on release deleted event workflow runs to be created
+          // if the tag is deleted before the workflow run is created, the run will fail to be created
+          await new Promise(resolve => setTimeout(resolve, SLEEP_DURATION * 1000));
+
+          if (DELETE_TAGS) {
+            for (let i = 0; i < preReleases.length - KEEP_LATEST; i++) {
               console.log(`Deleting tag: ${release.tag_name}`);
               try {
                 await github.rest.git.deleteRef({


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Add a delay before deleting tags to allow release deleted workflow runs to be created. If the tag doesn't exist when the run is initializing it will fail to be created.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
