### PR TITLE
fix: properly define release variable in delete tags loop

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -159,6 +159,7 @@ runs:
 
           if (DELETE_TAGS) {
             for (let i = 0; i < preReleases.length - KEEP_LATEST; i++) {
+              const release = preReleases[i];
               console.log(`Deleting tag: ${release.tag_name}`);
               try {
                 await github.rest.git.deleteRef({


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
Fixes the below error:

```txt
ReferenceError: release is not defined
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35424:16), <anonymous>:64:34)
    at async main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35522:20)
Error: Unhandled error: ReferenceError: release is not defined
```


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [ ] Documentation update (changes to documentation)
- [ ] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components

## Branch Updates
LizardByte requires that branches be up-to-date before merging. This means that after any PR is merged, this branch
must be updated before it can be merged. You must also
[Allow edits from maintainers](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I want maintainers to keep my branch updated
