### PR TITLE
feat!: remove discussion announcment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,23 +28,20 @@ jobs:
         id: setup-release
         uses: LizardByte/setup-release-action@master  # keep this on master, to prevent endless depandabot PRs
         with:
-          fail_on_events_api_error:  # PRs will fail if this is true
-            ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
+          # PRs will fail if this is true
+          fail_on_events_api_error: ${{ github.event_name == 'pull_request' && 'false' || 'true' }}
           github_token: ${{ secrets.GITHUB_TOKEN }}  # can use GITHUB_TOKEN for read-only access
 
       - name: Set action variables
         id: vars
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ]; then
-            discussion_category=tests
             release_tag=pr-${{ github.event.pull_request.number }}-${{ github.run_id }}
           else
-            discussion_category=announcements
             release_tag=${{ steps.setup-release.outputs.release_tag }}
           fi
 
           # set outputs
-          echo "discussion_category=$discussion_category" >> $GITHUB_OUTPUT
           echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
 
       - name: Run Action
@@ -54,7 +51,6 @@ jobs:
           allowUpdates: false
           artifacts: ''
           body: ${{ steps.setup-release.outputs.release_body }}
-          discussionCategory: ${{ steps.vars.outputs.discussion_category }}
           generateReleaseNotes: ${{ steps.setup-release.outputs.release_generate_release_notes }}
           name: ${{ steps.vars.outputs.release_tag }}
           prerelease: true

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ steps:
 | body                    | The body of the release.                                                                             |                 | `false`  |
 | deleteOtherPreReleases  | Whether to delete other pre-releases.                                                                | `true`          | `false`  |
 | deletePreReleaseTags    | Whether to delete other pre-release tags.                                                            | `true`          | `false`  |
-| discussionCategory      | The category for the discussion.                                                                     | `announcements` | `false`  |
 | generateReleaseNotes    | Indicates if release notes should be automatically generated.                                        | `true`          | `false`  |
 | keepPreReleaseCount     | The number of pre-releases to keep.                                                                  | `2`             | `false`  |
 | name                    | The version to create.                                                                               |                 | `true`   |

--- a/action.yml
+++ b/action.yml
@@ -27,10 +27,6 @@ inputs:
     description: 'Whether to delete other pre-releases tags.'
     required: false
     default: 'true'
-  discussionCategory:
-    description: 'The category of the discussion.'
-    required: false
-    default: 'announcements'
   generateReleaseNotes:
     description: 'Indicates if release notes should be automatically generated.'
     required: false
@@ -71,7 +67,6 @@ runs:
         artifacts: ${{ inputs.artifacts }}
         body: ${{ inputs.body }}
         commit: ${{ github.sha }}
-        discussionCategory: ${{ inputs.discussionCategory }}
         generateReleaseNotes: ${{ inputs.generateReleaseNotes }}
         name: ${{ inputs.name }}
         prerelease: ${{ inputs.prerelease }}


### PR DESCRIPTION
## Description
<!--- Please include a summary of the changes. --->
As we are moving to common discussions in `https://github.com/LizardByte/community`, we need to remove the announcement on releases because the API doesn't allow publishing discussions to a different repository.


### Screenshot
<!--- Include screenshots if the changes are UI-related. --->


### Issues Fixed or Closed
<!--- Close issue example: `- Closes #1` --->
<!--- Fix bug issue example: `- Fixes #2` --->
<!--- Resolve issue example: `- Resolves #3` --->


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update (updates to dependencies)
- [x] Documentation update (changes to documentation)
- [x] Repository update (changes to repository files, e.g. `.github/...`)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the in code docstring/documentation-blocks for new or existing methods/components
